### PR TITLE
Terraform を使って Amazon VPC をセットアップする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,8 @@ crash.log
 # Ignore any .tfvars files that are generated automatically for each Terraform run. Most
 # .tfvars files are managed as part of configuration and so should be included in
 # version control.
-#
-# example.tfvars
+
+terraform.tfvars
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in

--- a/main.tf
+++ b/main.tf
@@ -41,3 +41,14 @@ resource "aws_internet_gateway" "vpc-1-igw" {
     Name = "vpc-1-igw"
   }
 }
+
+resource "aws_route_table" "vpc-1-public-rt" {
+  vpc_id = aws_vpc.vpc-1.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.vpc-1-igw.id
+  }
+  tags = {
+    Name = "vpc-1-public-rt"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -34,3 +34,10 @@ resource "aws_subnet" "vpc-1-public-subnet" {
     Name = "vpc-1-public-subnet"
   }
 }
+
+resource "aws_internet_gateway" "vpc-1-igw" {
+  vpc_id = aws_vpc.vpc-1.id
+  tags = {
+    Name = "vpc-1-igw"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -2,15 +2,26 @@ variable "access_key" {}
 variable "secret_key" {}
 variable "region" {}
 
-provider "aws" {
-  access_key = "${var.access_key}"
-  secret_key = "${var.sevret_key}"
-  region = "${var.region}"
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+  }
 }
 
+# Configure the AWS Provider
+provider "aws" {
+  access_key = var.access_key
+  secret_key = var.secret_key
+  region = var.region
+}
+
+# Create a VPC
 resource "aws_vpc" "vpc-1" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "vpc-1"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -52,3 +52,8 @@ resource "aws_route_table" "vpc-1-public-rt" {
     Name = "vpc-1-public-rt"
   }
 }
+
+resource "aws_route_table_association" "vpc-1-rta-1" {
+  subnet_id = aws_subnet.vpc-1-public-subnet.id
+  route_table_id = aws_route_table.vpc-1-public-rt.id
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,16 @@
+variable "access_key" {}
+variable "secret_key" {}
+variable "region" {}
+
+provider "aws" {
+  access_key = "${var.access_key}"
+  secret_key = "${var.sevret_key}"
+  region = "${var.region}"
+}
+
+resource "aws_vpc" "vpc-1" {
+  cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "vpc-1"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -11,49 +11,8 @@ terraform {
   }
 }
 
-# Configure the AWS Provider
 provider "aws" {
   access_key = var.access_key
   secret_key = var.secret_key
   region = var.region
-}
-
-# Create a VPC
-resource "aws_vpc" "vpc-1" {
-  cidr_block = "10.0.0.0/16"
-  tags = {
-    Name = "vpc-1"
-  }
-}
-
-resource "aws_subnet" "vpc-1-public-subnet" {
-  vpc_id = aws_vpc.vpc-1.id
-  cidr_block = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
-  tags = {
-    Name = "vpc-1-public-subnet"
-  }
-}
-
-resource "aws_internet_gateway" "vpc-1-igw" {
-  vpc_id = aws_vpc.vpc-1.id
-  tags = {
-    Name = "vpc-1-igw"
-  }
-}
-
-resource "aws_route_table" "vpc-1-public-rt" {
-  vpc_id = aws_vpc.vpc-1.id
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.vpc-1-igw.id
-  }
-  tags = {
-    Name = "vpc-1-public-rt"
-  }
-}
-
-resource "aws_route_table_association" "vpc-1-rta-1" {
-  subnet_id = aws_subnet.vpc-1-public-subnet.id
-  route_table_id = aws_route_table.vpc-1-public-rt.id
 }

--- a/main.tf
+++ b/main.tf
@@ -25,3 +25,12 @@ resource "aws_vpc" "vpc-1" {
     Name = "vpc-1"
   }
 }
+
+resource "aws_subnet" "vpc-1-public-subnet" {
+  vpc_id = aws_vpc.vpc-1.id
+  cidr_block = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+  tags = {
+    Name = "vpc-1-public-subnet"
+  }
+}

--- a/terraform.tfvars.sample
+++ b/terraform.tfvars.sample
@@ -1,0 +1,4 @@
+access_key = "AWS_ACCESS_KEY"
+secret_key = "AWS_SECRET_KEY"
+region     = "ap-northeast-1"
+key_name   = "KEY_PAIR_NAME"

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,0 +1,38 @@
+resource "aws_vpc" "vpc-1" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = "vpc-1"
+  }
+}
+
+resource "aws_subnet" "vpc-1-public-subnet" {
+  vpc_id = aws_vpc.vpc-1.id
+  cidr_block = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+  tags = {
+    Name = "vpc-1-public-subnet"
+  }
+}
+
+resource "aws_internet_gateway" "vpc-1-igw" {
+  vpc_id = aws_vpc.vpc-1.id
+  tags = {
+    Name = "vpc-1-igw"
+  }
+}
+
+resource "aws_route_table" "vpc-1-public-rt" {
+  vpc_id = aws_vpc.vpc-1.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.vpc-1-igw.id
+  }
+  tags = {
+    Name = "vpc-1-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "vpc-1-rta-1" {
+  subnet_id = aws_subnet.vpc-1-public-subnet.id
+  route_table_id = aws_route_table.vpc-1-public-rt.id
+}


### PR DESCRIPTION
AWS VPCの環境構築を行う
Terraformを使用する

[こちらの記事](https://qiita.com/litencatt/items/8da20374def6320a014b#%E4%BB%A5%E9%99%8D%E3%81%AE%E4%BD%9C%E6%A5%AD)を参考に、[Terraform公式ドキュメント](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)を併用してセットアップした


## 実装

- パブリックサブネットの作成
- インターネットゲートウェイの作成
- パブリックルートテーブルの作成
- tfファイルの分割
